### PR TITLE
Add exit prompt

### DIFF
--- a/var_cleaner.py
+++ b/var_cleaner.py
@@ -121,6 +121,8 @@ def main() -> None:
         else:
             print("Deletion cancelled.")
 
+    input("Press Enter to exit...")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- prompt to press Enter before exiting var cleaner script

## Testing
- `printf '\nview\n\n' | python3 var_cleaner.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b590729483238fed68735e2f3764